### PR TITLE
Fix mesos.Credential.secret type mismatch

### DIFF
--- a/scheduler/init.go
+++ b/scheduler/init.go
@@ -41,13 +41,14 @@ func InitializeScheduler() (*DiegoScheduler, *sched.MesosSchedulerDriver) {
 	cred := (*mesos.Credential)(nil)
 	if *mesosAuthPrincipal != "" {
 		fwinfo.Principal = proto.String(*mesosAuthPrincipal)
-		secret, err := ioutil.ReadFile(*mesosAuthSecretFile)
+		secret_bytes, err := ioutil.ReadFile(*mesosAuthSecretFile)
+		secret = string(secret_bytes[:])
 		if err != nil {
 			log.Fatal(err)
 		}
 		cred = &mesos.Credential{
 			Principal: proto.String(*mesosAuthPrincipal),
-			Secret:    secret,
+			Secret:    &secret,
 		}
 	}
 	bindingAddress := parseIP(*address)


### PR DESCRIPTION
An Jan.16 2016 update of mesos/mesos-go changes type of
mesos.Credential.secret from bytes to string.

```
https://github.com/mesos/mesos-go/commit/7870a46fd9ad7d9d47dc518c46750c969c602bde#diff-8b984a6759078d3bd0e4a27e90ab541dR1239
```

This results a type mismatch at scheduler/init.go:50. Error
message below

```
cannot use secret (type []byte) as type *string in field value
```

This patch fixes it by converting `secret` from []byte to string
before passing it to mesos.Credential.
